### PR TITLE
Replace use of 'panic' in proof generation with Either

### DIFF
--- a/Bulletproofs/InnerProductProof/Internal.hs
+++ b/Bulletproofs/InnerProductProof/Internal.hs
@@ -2,6 +2,7 @@ module Bulletproofs.InnerProductProof.Internal (
   InnerProductProof(..),
   InnerProductWitness(..),
   InnerProductBase(..),
+  InnerProductProofErr(..),
 ) where
 
 import Protolude
@@ -44,3 +45,6 @@ data InnerProductBase
     -- for which there is no known discrete-log relation among Gs, Hs, bG
     } deriving (Show, Eq)
 
+data InnerProductProofErr
+  = AssertionError Text Text -- ^ Two values that must be equal are not
+  deriving (Show)

--- a/Bulletproofs/RangeProof/Internal.hs
+++ b/Bulletproofs/RangeProof/Internal.hs
@@ -58,6 +58,8 @@ data RangeProofError
   = UpperBoundTooLarge Integer  -- ^ The upper bound of the range is too large
   | ValueNotInRange Integer     -- ^ Value is not within the range required
   | NNotPowerOf2 Integer        -- ^ Dimension n is required to be a power of 2
+  | AssertionError Text Text    -- ^ Two values expected to be equal are not
+  | InnerProductProofErr InnerProductProofErr -- ^ Error when generating the inner product proof
   deriving (Show)
 
 -----------------------------


### PR DESCRIPTION
Instead of exceptions being thrown during proof generation, we report them as `AssertionError` values, using the Either type. 