### PR TITLE
Allow client to accept a number of gates that is not a power of 2

### DIFF
--- a/Bulletproofs/ArithmeticCircuit/Internal.hs
+++ b/Bulletproofs/ArithmeticCircuit/Internal.hs
@@ -9,16 +9,14 @@ import qualified Data.Map as Map
 
 import System.Random.Shuffle (shuffleM)
 import qualified Crypto.Random.Types as Crypto (MonadRandom(..))
-import Crypto.Number.Generate (generateMax, generateBetween)
+import Crypto.Number.Generate (generateMax)
 import Control.Monad.Random (MonadRandom)
 import qualified Crypto.PubKey.ECC.Types as Crypto
-import qualified Crypto.PubKey.ECC.Prim as Crypto
 import Linear.Vector ((^+^), (^-^))
 import Linear.Metric (dot)
 
 import Bulletproofs.Curve
 import Bulletproofs.Utils
-import Bulletproofs.RangeProof.Internal
 import qualified Bulletproofs.InnerProductProof as IPP
 
 data ArithCircuitProofError
@@ -35,7 +33,8 @@ data ArithCircuitProof f
     , aoCommit :: Crypto.Point
     , sCommit :: Crypto.Point
     , tCommits :: [Crypto.Point]
-    , productProof :: IPP.InnerProductProof f
+    , productProofM :: Maybe (IPP.InnerProductProof f)
+    , lrM :: Maybe ([f], [f])
     } deriving (Show, Eq)
 
 data ArithCircuit f

--- a/Bulletproofs/ArithmeticCircuit/Verifier.hs
+++ b/Bulletproofs/ArithmeticCircuit/Verifier.hs
@@ -62,15 +62,18 @@ verifyProof vCommits proof@ArithCircuitProof{..} ArithCircuit{..}
         cQ = zs `dot` cs
         vExp = (*) (fSquare x) <$> (zs `vectorMatrixProduct` commitmentWeights)
         k = delta n y zwL zwR
-        xs = 0 : x : 0 : (((^) x) <$> [3..6])
+        xs = 0 : x : 0 : ((^) x <$> [3..6])
         tCommitsExpSum = foldl' addP Crypto.PointO (zipWith mulP xs tCommits)
 
     verifyLRCommitment
-      = IPP.verifyProof
-          n
-          IPP.InnerProductBase { bGs = gs, bHs = hs', bH = u }
-          commitmentLR
-          productProof
+      = case productProofM of
+        Just productProof
+          -> IPP.verifyProof
+               n
+               IPP.InnerProductBase { bGs = gs, bHs = hs', bH = u }
+               commitmentLR
+               productProof
+        Nothing -> notImplemented
       where
         gExp = (*) x <$> (powerVector (recip y) n `hadamardp` zwR)
         hExp = (((*) x <$> zwL) ^+^ zwO) ^-^ ys


### PR DESCRIPTION
This PR is more a suggestion than a firm decision. Here's a way to handle cases where the number of gates `n` is not a power of 2:
We compute the proof with the inner product proof only in these specific cases. Otherwise, we save a longer proof with vectors `l` and `r` in it